### PR TITLE
[props] implement MQTT 5 properties subsystem

### DIFF
--- a/amqtt/codecs_amqtt.py
+++ b/amqtt/codecs_amqtt.py
@@ -3,7 +3,9 @@ from decimal import ROUND_HALF_UP, Decimal
 from struct import pack, unpack
 
 from amqtt.adapters import ReaderAdapter
-from amqtt.errors import NoDataError, ZeroLengthReadError
+from amqtt.errors import CodecError, MQTTError, NoDataError, ZeroLengthReadError
+
+MAX_VARIABLE_BYTE_INTEGER = 268_435_455
 
 
 def bytes_to_hex_str(data: bytes | bytearray) -> str:
@@ -31,7 +33,7 @@ def int_to_bytes(int_value: int, length: int) -> bytes:
     """Convert an integer to a sequence of bytes using big endian byte ordering.
 
     :param int_value: integer value to convert
-    :param length: byte length (must be 1 or 2)
+    :param length: byte length (must be 1, 2, or 4)
     :return: byte sequence
     :raises ValueError: if the length is unsupported
     """
@@ -39,14 +41,102 @@ def int_to_bytes(int_value: int, length: int) -> bytes:
     fmt_mapping = {
         1: "!B",  # 1 byte, unsigned char
         2: "!H",  # 2 bytes, unsigned short
+        4: "!L",  # 4 bytes, unsigned long
     }
 
     fmt = fmt_mapping.get(length)
     if not fmt:
-        msg = "Unsupported length for int to bytes conversion. Only lengths 1 or 2 are allowed."
+        msg = "Unsupported length for int to bytes conversion. Only lengths 1, 2, or 4 are allowed."
         raise ValueError(msg)
 
     return pack(fmt, int_value)
+
+
+def encode_variable_byte_int(value: int) -> bytes:
+    """Encode an MQTT Variable Byte Integer.
+
+    MQTT uses this format for Remaining Length and MQTT 5 Properties length
+    fields. The valid range is 0 through 268,435,455.
+
+    :param value: integer value to encode
+    :return: MQTT Variable Byte Integer bytes.
+    :raises CodecError: if the value is outside the MQTT range.
+    """
+    if value < 0 or value > MAX_VARIABLE_BYTE_INTEGER:
+        msg = f"Variable Byte Integer out of range: {value}"
+        raise CodecError(msg)
+
+    encoded = bytearray()
+    while True:
+        encoded_byte = value % 0x80
+        value //= 0x80
+        if value > 0:
+            encoded_byte |= 0x80
+        encoded.append(encoded_byte)
+        if value <= 0:
+            break
+    return bytes(encoded)
+
+
+def decode_variable_byte_int(data: bytes | bytearray, offset: int = 0) -> tuple[int, int]:
+    """Decode an MQTT Variable Byte Integer from bytes.
+
+    :param data: bytes containing the encoded integer.
+    :param offset: first byte to decode.
+    :return: tuple of decoded value and next unread offset.
+    :raises MQTTError: if the encoding is malformed or incomplete.
+    """
+    multiplier = 1
+    value = 0
+    index = offset
+    buffer = bytearray()
+
+    while True:
+        if index >= len(data):
+            msg = f"Incomplete Variable Byte Integer bytes:{bytes_to_hex_str(buffer)}"
+            raise MQTTError(msg)
+
+        encoded_byte = data[index]
+        buffer.append(encoded_byte)
+        index += 1
+
+        value += (encoded_byte & 0x7F) * multiplier
+        if (encoded_byte & 0x80) == 0:
+            return value, index
+
+        multiplier *= 128
+        if multiplier > 128**3:
+            msg = f"Invalid Variable Byte Integer bytes:{bytes_to_hex_str(buffer)}"
+            raise MQTTError(msg)
+
+
+async def decode_variable_byte_int_from_stream(reader: ReaderAdapter | asyncio.StreamReader) -> int:
+    """Read and decode an MQTT Variable Byte Integer from a stream.
+
+    :param reader: reader adapter
+    :return: decoded integer value.
+    :raises MQTTError: if the encoding uses more than four bytes.
+    :raises NoDataError: if the stream closes before a byte is available.
+    """
+    multiplier = 1
+    value = 0
+    buffer = bytearray()
+
+    while True:
+        encoded = await read_or_raise(reader, 1)
+        if len(encoded) != 1:
+            msg = "No more data"
+            raise NoDataError(msg)
+        encoded_byte = unpack("!B", encoded)[0]
+        buffer.append(encoded_byte)
+        value += (encoded_byte & 0x7F) * multiplier
+        if (encoded_byte & 0x80) == 0:
+            return int(value)
+
+        multiplier *= 128
+        if multiplier > 128**3:
+            msg = f"Invalid Variable Byte Integer bytes:{bytes_to_hex_str(buffer)}"
+            raise MQTTError(msg)
 
 
 async def read_or_raise(reader: ReaderAdapter | asyncio.StreamReader, n: int = -1) -> bytes:

--- a/amqtt/mqtt3/packet.py
+++ b/amqtt/mqtt3/packet.py
@@ -1,20 +1,21 @@
 from abc import ABC, abstractmethod
 import asyncio
-
-try:
-    from datetime import UTC, datetime
-except ImportError:
-    from datetime import datetime, timezone
-
-    UTC = timezone.utc
-
+from datetime import datetime, timezone
 from struct import unpack
 from typing import Generic
 from typing_extensions import Self, TypeVar
 
 from amqtt.adapters import ReaderAdapter, WriterAdapter
-from amqtt.codecs_amqtt import bytes_to_hex_str, decode_packet_id, int_to_bytes, read_or_raise
-from amqtt.errors import CodecError, MQTTError, NoDataError
+from amqtt.codecs_amqtt import (
+    decode_packet_id,
+    decode_variable_byte_int_from_stream,
+    encode_variable_byte_int,
+    int_to_bytes,
+    read_or_raise,
+)
+from amqtt.errors import CodecError, NoDataError
+
+UTC = timezone.utc
 
 RESERVED_0 = 0x00
 CONNECT = 0x01
@@ -46,25 +47,11 @@ class MQTTFixedHeader:
 
     def to_bytes(self) -> bytes:
         """Encode the fixed header to bytes."""
-
-        def encode_remaining_length(length: int) -> bytes:
-            """Encode the remaining length as per MQTT protocol."""
-            encoded = bytearray()
-            while True:
-                length_byte = length % 0x80
-                length //= 0x80
-                if length > 0:
-                    length_byte |= 0x80
-                encoded.append(length_byte)
-                if length <= 0:
-                    break
-            return bytes(encoded)
-
         try:
             packet_type_flags = (self.packet_type << 4) | self.flags
-            encoded_length = encode_remaining_length(self.remaining_length)
+            encoded_length = encode_variable_byte_int(self.remaining_length)
             return bytes([packet_type_flags]) + encoded_length
-        except OverflowError as exc:
+        except (CodecError, OverflowError) as exc:
             msg = f"Fixed header encoding failed: {exc}"
             raise CodecError(msg) from exc
 
@@ -79,32 +66,12 @@ class MQTTFixedHeader:
     @classmethod
     async def from_stream(cls: type[Self], reader: ReaderAdapter) -> "Self | None":
         """Decode a fixed header from the stream."""
-
-        async def decode_remaining_length() -> int:
-            """Decode the remaining length from the stream."""
-            multiplier: int
-            value: int
-            multiplier, value = 1, 0
-            buffer = bytearray()
-            while True:
-                encoded_byte = await reader.read(1)
-                byte_value = unpack("!B", encoded_byte)[0]
-                buffer.append(byte_value)
-                value += (byte_value & 0x7F) * multiplier
-                if (byte_value & 0x80) == 0:
-                    break
-                multiplier *= 128
-                if multiplier > 128**3:
-                    msg = f"Invalid remaining length bytes:{bytes_to_hex_str(buffer)}, packet_type={packet_type}"
-                    raise MQTTError(msg)
-            return value
-
         try:
             byte1 = await read_or_raise(reader, 1)
             int1 = unpack("!B", byte1)[0]
             packet_type = (int1 & 0xF0) >> 4
             flags = int1 & 0x0F
-            remaining_length = await decode_remaining_length()
+            remaining_length = await decode_variable_byte_int_from_stream(reader)
             return cls(packet_type, flags, remaining_length)
         except NoDataError:
             return None

--- a/amqtt/mqtt5/properties.py
+++ b/amqtt/mqtt5/properties.py
@@ -1,0 +1,333 @@
+"""MQTT 5.0 Properties encoding and decoding (§2.2.2)."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, TypeAlias, cast
+from typing_extensions import Self
+
+from amqtt.codecs_amqtt import (
+    bytes_to_int,
+    decode_variable_byte_int,
+    decode_variable_byte_int_from_stream,
+    encode_data_with_length,
+    encode_string,
+    encode_variable_byte_int,
+    int_to_bytes,
+    read_or_raise,
+)
+from amqtt.errors import MQTTError
+from amqtt.mqtt5.property_ids import PROPERTY_DEFINITIONS, PropertyDefinition, PropertyWireType
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator
+
+    from amqtt.adapters import ReaderAdapter
+
+PropertyValue: TypeAlias = int | str | bytes | bytearray | tuple[str, str] | list[int] | list[tuple[str, str]]
+
+
+class Properties:
+    """Container for MQTT 5.0 packet properties.
+
+    Properties are keyed by MQTT property identifier. Duplicate non-repeatable
+    properties raise `MQTTError`; repeatable properties preserve insertion order.
+    """
+
+    def __init__(self, values: dict[int, PropertyValue] | None = None) -> None:
+        self._values: dict[int, PropertyValue] = {}
+        if values:
+            for identifier, value in values.items():
+                self.set(identifier, value)
+
+    def set(self, identifier: int, value: PropertyValue) -> None:
+        """Set a property value.
+
+        Args:
+            identifier: MQTT 5.0 property identifier.
+            value: Property value using the Python type for its wire type.
+
+        Raises:
+            MQTTError: If the identifier is unknown, the value has the wrong
+                type, or a duplicate non-repeatable property is added.
+
+        """
+        definition = _definition(identifier)
+        normalized = _normalize_value(definition, value)
+
+        if definition.repeatable:
+            existing = self._values.get(identifier)
+            if existing is None:
+                self._values[identifier] = normalized
+                return
+            if not isinstance(existing, list) or not isinstance(normalized, list):
+                msg = f"Repeatable property {definition.name} must be stored as a list"
+                raise MQTTError(msg)
+            cast("list[Any]", existing).extend(cast("list[Any]", normalized))
+            return
+
+        if identifier in self._values:
+            msg = f"Duplicate MQTT 5.0 property: {definition.name}"
+            raise MQTTError(msg)
+        self._values[identifier] = normalized
+
+    def get(self, identifier: int, default: PropertyValue | None = None) -> PropertyValue | None:
+        """Return a property value by identifier.
+
+        Args:
+            identifier: MQTT 5.0 property identifier.
+            default: Value returned when the property is not present.
+
+        Returns:
+            The stored property value or `default`.
+
+        """
+        return self._values.get(identifier, default)
+
+    def has(self, identifier: int) -> bool:
+        """Return whether a property identifier is present."""
+        return identifier in self._values
+
+    def encode(self) -> bytes:
+        r"""Encode properties with the MQTT 5.0 length prefix.
+
+        Returns:
+            MQTT 5.0 Properties bytes. Empty properties encode as `b"\\x00"`.
+
+        """
+        payload = bytearray()
+        for identifier, value in self._values.items():
+            definition = _definition(identifier)
+            if definition.repeatable:
+                if not isinstance(value, list):
+                    msg = f"Repeatable property {definition.name} must be stored as a list"
+                    raise MQTTError(msg)
+                for item in value:
+                    payload.extend(_encode_property(definition, item))
+            else:
+                payload.extend(_encode_property(definition, value))
+        return encode_variable_byte_int(len(payload)) + bytes(payload)
+
+    @classmethod
+    def decode(cls: type[Self], data: bytes | bytearray) -> Self:
+        """Decode MQTT 5.0 Properties from bytes.
+
+        Args:
+            data: MQTT 5.0 Properties bytes including the length prefix.
+
+        Returns:
+            Decoded `Properties`.
+
+        Raises:
+            MQTTError: If the property section is malformed.
+
+        """
+        property_length, offset = decode_variable_byte_int(data)
+        end = offset + property_length
+        if end > len(data):
+            msg = "Properties length exceeds available bytes"
+            raise MQTTError(msg)
+        if end != len(data):
+            msg = "Properties bytes contain trailing data"
+            raise MQTTError(msg)
+
+        properties = cls()
+        while offset < end:
+            identifier, offset = decode_variable_byte_int(data, offset)
+            definition = _definition(identifier)
+            value, offset = _decode_property(definition, data, offset, end)
+            properties.set(identifier, value)
+        return properties
+
+    @classmethod
+    async def from_stream(cls: type[Self], reader: ReaderAdapter) -> Self:
+        """Read and decode MQTT 5.0 Properties from a stream."""
+        property_length = await decode_variable_byte_int_from_stream(reader)
+        data = await read_or_raise(reader, property_length)
+        if len(data) != property_length:
+            msg = "Properties length exceeds available stream bytes"
+            raise MQTTError(msg)
+        return cls.decode(encode_variable_byte_int(property_length) + data)
+
+    def items(self) -> Iterable[tuple[int, PropertyValue]]:
+        """Return stored property identifier/value pairs."""
+        return self._values.items()
+
+    def __iter__(self) -> Iterator[int]:
+        """Return an iterator over stored property identifiers."""
+        return iter(self._values)
+
+    def __eq__(self, other: object) -> bool:
+        """Compare properties by stored identifier/value pairs."""
+        if not isinstance(other, Properties):
+            return False
+        return self._values == other._values
+
+    def __repr__(self) -> str:
+        """Return a developer-friendly representation."""
+        return f"{self.__class__.__name__}({self._values!r})"
+
+
+def _definition(identifier: int) -> PropertyDefinition:
+    try:
+        return PROPERTY_DEFINITIONS[identifier]
+    except KeyError as exc:
+        msg = f"Unknown MQTT 5.0 property identifier: {identifier:#x}"
+        raise MQTTError(msg) from exc
+
+
+def _normalize_value(definition: PropertyDefinition, value: PropertyValue) -> PropertyValue:
+    if definition.repeatable:
+        if definition.wire_type is PropertyWireType.UTF8_STRING_PAIR:
+            if isinstance(value, tuple):
+                _validate_string_pair(definition, value)
+                return [value]
+            if isinstance(value, list):
+                for item in value:
+                    _validate_string_pair(definition, item)
+                return value
+        elif definition.wire_type is PropertyWireType.VARIABLE_BYTE_INTEGER:
+            if isinstance(value, int):
+                _validate_int(definition, value, 0, 268_435_455)
+                return [value]
+            if isinstance(value, list) and all(isinstance(item, int) for item in value):
+                for item in value:
+                    _validate_int(definition, item, 0, 268_435_455)
+                return value
+        msg = f"Invalid value for repeatable property {definition.name}: {value!r}"
+        raise MQTTError(msg)
+
+    _validate_single_value(definition, value)
+    return value
+
+
+def _validate_single_value(definition: PropertyDefinition, value: Any) -> None:
+    match definition.wire_type:
+        case PropertyWireType.BYTE:
+            _validate_int(definition, value, 0, 0xFF)
+        case PropertyWireType.TWO_BYTE_INTEGER:
+            _validate_int(definition, value, 0, 0xFFFF)
+        case PropertyWireType.FOUR_BYTE_INTEGER:
+            _validate_int(definition, value, 0, 0xFFFF_FFFF)
+        case PropertyWireType.VARIABLE_BYTE_INTEGER:
+            _validate_int(definition, value, 0, 268_435_455)
+        case PropertyWireType.UTF8_STRING:
+            if not isinstance(value, str):
+                msg = f"Property {definition.name} requires a string value"
+                raise MQTTError(msg)
+        case PropertyWireType.UTF8_STRING_PAIR:
+            _validate_string_pair(definition, value)
+        case PropertyWireType.BINARY_DATA:
+            if not isinstance(value, (bytes, bytearray)):
+                msg = f"Property {definition.name} requires bytes"
+                raise MQTTError(msg)
+
+
+def _validate_int(definition: PropertyDefinition, value: Any, minimum: int, maximum: int) -> None:
+    if not isinstance(value, int) or value < minimum or value > maximum:
+        msg = f"Property {definition.name} requires an integer from {minimum} to {maximum}"
+        raise MQTTError(msg)
+
+
+def _validate_string_pair(definition: PropertyDefinition, value: Any) -> None:
+    if (
+        not isinstance(value, tuple)
+        or len(value) != 2
+        or not isinstance(value[0], str)
+        or not isinstance(value[1], str)
+    ):
+        msg = f"Property {definition.name} requires a string pair"
+        raise MQTTError(msg)
+
+
+def _encode_property(definition: PropertyDefinition, value: Any) -> bytes:
+    out = bytearray(encode_variable_byte_int(definition.identifier))
+    match definition.wire_type:
+        case PropertyWireType.BYTE:
+            _validate_int(definition, value, 0, 0xFF)
+            out.extend(int_to_bytes(value, 1))
+        case PropertyWireType.TWO_BYTE_INTEGER:
+            _validate_int(definition, value, 0, 0xFFFF)
+            out.extend(int_to_bytes(value, 2))
+        case PropertyWireType.FOUR_BYTE_INTEGER:
+            _validate_int(definition, value, 0, 0xFFFF_FFFF)
+            out.extend(int_to_bytes(value, 4))
+        case PropertyWireType.VARIABLE_BYTE_INTEGER:
+            _validate_int(definition, value, 0, 268_435_455)
+            out.extend(encode_variable_byte_int(value))
+        case PropertyWireType.UTF8_STRING:
+            if not isinstance(value, str):
+                msg = f"Property {definition.name} requires a string value"
+                raise MQTTError(msg)
+            out.extend(encode_string(value))
+        case PropertyWireType.UTF8_STRING_PAIR:
+            _validate_string_pair(definition, value)
+            out.extend(encode_string(value[0]))
+            out.extend(encode_string(value[1]))
+        case PropertyWireType.BINARY_DATA:
+            if not isinstance(value, (bytes, bytearray)):
+                msg = f"Property {definition.name} requires bytes"
+                raise MQTTError(msg)
+            out.extend(encode_data_with_length(value))
+    return bytes(out)
+
+
+def _decode_property(definition: PropertyDefinition, data: bytes | bytearray, offset: int, end: int) -> tuple[PropertyValue, int]:
+    if offset > end:
+        msg = f"Property {definition.name} exceeds properties length"
+        raise MQTTError(msg)
+
+    match definition.wire_type:
+        case PropertyWireType.BYTE:
+            _require_available(definition, offset, end, 1)
+            return data[offset], offset + 1
+        case PropertyWireType.TWO_BYTE_INTEGER:
+            _require_available(definition, offset, end, 2)
+            return bytes_to_int(bytes(data[offset:offset + 2])), offset + 2
+        case PropertyWireType.FOUR_BYTE_INTEGER:
+            _require_available(definition, offset, end, 4)
+            return bytes_to_int(bytes(data[offset:offset + 4])), offset + 4
+        case PropertyWireType.VARIABLE_BYTE_INTEGER:
+            return decode_variable_byte_int(data, offset)
+        case PropertyWireType.UTF8_STRING:
+            value, next_offset = _decode_string_from_bytes(data, offset, end)
+            return value, next_offset
+        case PropertyWireType.UTF8_STRING_PAIR:
+            key, next_offset = _decode_string_from_bytes(data, offset, end)
+            value, next_offset = _decode_string_from_bytes(data, next_offset, end)
+            return (key, value), next_offset
+        case PropertyWireType.BINARY_DATA:
+            binary_value, next_offset = _decode_data_from_bytes(data, offset, end)
+            return binary_value, next_offset
+
+
+def _require_available(definition: PropertyDefinition, offset: int, end: int, needed: int) -> None:
+    if offset + needed > end:
+        msg = f"Property {definition.name} exceeds properties length"
+        raise MQTTError(msg)
+
+
+def _decode_string_from_bytes(data: bytes | bytearray, offset: int, end: int) -> tuple[str, int]:
+    if offset + 2 > end:
+        msg = "String property length exceeds properties length"
+        raise MQTTError(msg)
+    length = bytes_to_int(bytes(data[offset:offset + 2]))
+    offset += 2
+    if offset + length > end:
+        msg = "String property value exceeds properties length"
+        raise MQTTError(msg)
+    try:
+        return bytes(data[offset:offset + length]).decode("utf-8"), offset + length
+    except UnicodeDecodeError as exc:
+        msg = "String property value is not valid UTF-8"
+        raise MQTTError(msg) from exc
+
+
+def _decode_data_from_bytes(data: bytes | bytearray, offset: int, end: int) -> tuple[bytes, int]:
+    if offset + 2 > end:
+        msg = "Binary property length exceeds properties length"
+        raise MQTTError(msg)
+    length = bytes_to_int(bytes(data[offset:offset + 2]))
+    offset += 2
+    if offset + length > end:
+        msg = "Binary property value exceeds properties length"
+        raise MQTTError(msg)
+    return bytes(data[offset:offset + length]), offset + length

--- a/amqtt/mqtt5/property_ids.py
+++ b/amqtt/mqtt5/property_ids.py
@@ -1,0 +1,273 @@
+"""MQTT 5.0 property identifiers and wire metadata."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import TypeAlias
+
+PacketName: TypeAlias = str
+
+PACKET_CONNECT = "CONNECT"
+PACKET_CONNACK = "CONNACK"
+PACKET_PUBLISH = "PUBLISH"
+PACKET_PUBACK = "PUBACK"
+PACKET_PUBREC = "PUBREC"
+PACKET_PUBREL = "PUBREL"
+PACKET_PUBCOMP = "PUBCOMP"
+PACKET_SUBSCRIBE = "SUBSCRIBE"
+PACKET_SUBACK = "SUBACK"
+PACKET_UNSUBSCRIBE = "UNSUBSCRIBE"
+PACKET_UNSUBACK = "UNSUBACK"
+PACKET_DISCONNECT = "DISCONNECT"
+PACKET_AUTH = "AUTH"
+PACKET_WILL = "WILL"
+
+
+class PropertyWireType(Enum):
+    """MQTT 5.0 property value wire types."""
+
+    BYTE = "byte"
+    TWO_BYTE_INTEGER = "two_byte_integer"
+    FOUR_BYTE_INTEGER = "four_byte_integer"
+    VARIABLE_BYTE_INTEGER = "variable_byte_integer"
+    UTF8_STRING = "utf8_string"
+    UTF8_STRING_PAIR = "utf8_string_pair"
+    BINARY_DATA = "binary_data"
+
+
+@dataclass(frozen=True)
+class PropertyDefinition:
+    """Metadata for an MQTT 5.0 property identifier."""
+
+    identifier: int
+    name: str
+    wire_type: PropertyWireType
+    packets: frozenset[PacketName]
+    repeatable: bool = False
+
+
+PAYLOAD_FORMAT_INDICATOR = 0x01
+MESSAGE_EXPIRY_INTERVAL = 0x02
+CONTENT_TYPE = 0x03
+RESPONSE_TOPIC = 0x08
+CORRELATION_DATA = 0x09
+SUBSCRIPTION_IDENTIFIER = 0x0B
+SESSION_EXPIRY_INTERVAL = 0x11
+ASSIGNED_CLIENT_IDENTIFIER = 0x12
+SERVER_KEEP_ALIVE = 0x13
+AUTHENTICATION_METHOD = 0x15
+AUTHENTICATION_DATA = 0x16
+REQUEST_PROBLEM_INFORMATION = 0x17
+WILL_DELAY_INTERVAL = 0x18
+REQUEST_RESPONSE_INFORMATION = 0x19
+RESPONSE_INFORMATION = 0x1A
+SERVER_REFERENCE = 0x1C
+REASON_STRING = 0x1F
+RECEIVE_MAXIMUM = 0x21
+TOPIC_ALIAS_MAXIMUM = 0x22
+TOPIC_ALIAS = 0x23
+MAXIMUM_QOS = 0x24
+RETAIN_AVAILABLE = 0x25
+USER_PROPERTY = 0x26
+MAXIMUM_PACKET_SIZE = 0x27
+WILDCARD_SUBSCRIPTION_AVAILABLE = 0x28
+SUBSCRIPTION_IDENTIFIER_AVAILABLE = 0x29
+SHARED_SUBSCRIPTION_AVAILABLE = 0x2A
+
+
+PROPERTY_DEFINITIONS: dict[int, PropertyDefinition] = {
+    PAYLOAD_FORMAT_INDICATOR: PropertyDefinition(
+        PAYLOAD_FORMAT_INDICATOR,
+        "Payload Format Indicator",
+        PropertyWireType.BYTE,
+        frozenset({PACKET_PUBLISH, PACKET_WILL}),
+    ),
+    MESSAGE_EXPIRY_INTERVAL: PropertyDefinition(
+        MESSAGE_EXPIRY_INTERVAL,
+        "Message Expiry Interval",
+        PropertyWireType.FOUR_BYTE_INTEGER,
+        frozenset({PACKET_PUBLISH, PACKET_WILL}),
+    ),
+    CONTENT_TYPE: PropertyDefinition(
+        CONTENT_TYPE,
+        "Content Type",
+        PropertyWireType.UTF8_STRING,
+        frozenset({PACKET_PUBLISH, PACKET_WILL}),
+    ),
+    RESPONSE_TOPIC: PropertyDefinition(
+        RESPONSE_TOPIC,
+        "Response Topic",
+        PropertyWireType.UTF8_STRING,
+        frozenset({PACKET_PUBLISH, PACKET_WILL}),
+    ),
+    CORRELATION_DATA: PropertyDefinition(
+        CORRELATION_DATA,
+        "Correlation Data",
+        PropertyWireType.BINARY_DATA,
+        frozenset({PACKET_PUBLISH, PACKET_WILL}),
+    ),
+    SUBSCRIPTION_IDENTIFIER: PropertyDefinition(
+        SUBSCRIPTION_IDENTIFIER,
+        "Subscription Identifier",
+        PropertyWireType.VARIABLE_BYTE_INTEGER,
+        frozenset({PACKET_PUBLISH, PACKET_SUBSCRIBE}),
+        repeatable=True,
+    ),
+    SESSION_EXPIRY_INTERVAL: PropertyDefinition(
+        SESSION_EXPIRY_INTERVAL,
+        "Session Expiry Interval",
+        PropertyWireType.FOUR_BYTE_INTEGER,
+        frozenset({PACKET_CONNECT, PACKET_CONNACK, PACKET_DISCONNECT}),
+    ),
+    ASSIGNED_CLIENT_IDENTIFIER: PropertyDefinition(
+        ASSIGNED_CLIENT_IDENTIFIER,
+        "Assigned Client Identifier",
+        PropertyWireType.UTF8_STRING,
+        frozenset({PACKET_CONNACK}),
+    ),
+    SERVER_KEEP_ALIVE: PropertyDefinition(
+        SERVER_KEEP_ALIVE,
+        "Server Keep Alive",
+        PropertyWireType.TWO_BYTE_INTEGER,
+        frozenset({PACKET_CONNACK}),
+    ),
+    AUTHENTICATION_METHOD: PropertyDefinition(
+        AUTHENTICATION_METHOD,
+        "Authentication Method",
+        PropertyWireType.UTF8_STRING,
+        frozenset({PACKET_CONNECT, PACKET_CONNACK, PACKET_AUTH}),
+    ),
+    AUTHENTICATION_DATA: PropertyDefinition(
+        AUTHENTICATION_DATA,
+        "Authentication Data",
+        PropertyWireType.BINARY_DATA,
+        frozenset({PACKET_CONNECT, PACKET_CONNACK, PACKET_AUTH}),
+    ),
+    REQUEST_PROBLEM_INFORMATION: PropertyDefinition(
+        REQUEST_PROBLEM_INFORMATION,
+        "Request Problem Information",
+        PropertyWireType.BYTE,
+        frozenset({PACKET_CONNECT}),
+    ),
+    WILL_DELAY_INTERVAL: PropertyDefinition(
+        WILL_DELAY_INTERVAL,
+        "Will Delay Interval",
+        PropertyWireType.FOUR_BYTE_INTEGER,
+        frozenset({PACKET_WILL}),
+    ),
+    REQUEST_RESPONSE_INFORMATION: PropertyDefinition(
+        REQUEST_RESPONSE_INFORMATION,
+        "Request Response Information",
+        PropertyWireType.BYTE,
+        frozenset({PACKET_CONNECT}),
+    ),
+    RESPONSE_INFORMATION: PropertyDefinition(
+        RESPONSE_INFORMATION,
+        "Response Information",
+        PropertyWireType.UTF8_STRING,
+        frozenset({PACKET_CONNACK}),
+    ),
+    SERVER_REFERENCE: PropertyDefinition(
+        SERVER_REFERENCE,
+        "Server Reference",
+        PropertyWireType.UTF8_STRING,
+        frozenset({PACKET_CONNACK, PACKET_DISCONNECT}),
+    ),
+    REASON_STRING: PropertyDefinition(
+        REASON_STRING,
+        "Reason String",
+        PropertyWireType.UTF8_STRING,
+        frozenset({
+            PACKET_CONNACK,
+            PACKET_PUBACK,
+            PACKET_PUBREC,
+            PACKET_PUBREL,
+            PACKET_PUBCOMP,
+            PACKET_SUBACK,
+            PACKET_UNSUBACK,
+            PACKET_DISCONNECT,
+            PACKET_AUTH,
+        }),
+    ),
+    RECEIVE_MAXIMUM: PropertyDefinition(
+        RECEIVE_MAXIMUM,
+        "Receive Maximum",
+        PropertyWireType.TWO_BYTE_INTEGER,
+        frozenset({PACKET_CONNECT, PACKET_CONNACK}),
+    ),
+    TOPIC_ALIAS_MAXIMUM: PropertyDefinition(
+        TOPIC_ALIAS_MAXIMUM,
+        "Topic Alias Maximum",
+        PropertyWireType.TWO_BYTE_INTEGER,
+        frozenset({PACKET_CONNECT, PACKET_CONNACK}),
+    ),
+    TOPIC_ALIAS: PropertyDefinition(
+        TOPIC_ALIAS,
+        "Topic Alias",
+        PropertyWireType.TWO_BYTE_INTEGER,
+        frozenset({PACKET_PUBLISH}),
+    ),
+    MAXIMUM_QOS: PropertyDefinition(
+        MAXIMUM_QOS,
+        "Maximum QoS",
+        PropertyWireType.BYTE,
+        frozenset({PACKET_CONNACK}),
+    ),
+    RETAIN_AVAILABLE: PropertyDefinition(
+        RETAIN_AVAILABLE,
+        "Retain Available",
+        PropertyWireType.BYTE,
+        frozenset({PACKET_CONNACK}),
+    ),
+    USER_PROPERTY: PropertyDefinition(
+        USER_PROPERTY,
+        "User Property",
+        PropertyWireType.UTF8_STRING_PAIR,
+        frozenset({
+            PACKET_CONNECT,
+            PACKET_CONNACK,
+            PACKET_PUBLISH,
+            PACKET_PUBACK,
+            PACKET_PUBREC,
+            PACKET_PUBREL,
+            PACKET_PUBCOMP,
+            PACKET_SUBSCRIBE,
+            PACKET_SUBACK,
+            PACKET_UNSUBSCRIBE,
+            PACKET_UNSUBACK,
+            PACKET_DISCONNECT,
+            PACKET_AUTH,
+            PACKET_WILL,
+        }),
+        repeatable=True,
+    ),
+    MAXIMUM_PACKET_SIZE: PropertyDefinition(
+        MAXIMUM_PACKET_SIZE,
+        "Maximum Packet Size",
+        PropertyWireType.FOUR_BYTE_INTEGER,
+        frozenset({PACKET_CONNECT, PACKET_CONNACK}),
+    ),
+    WILDCARD_SUBSCRIPTION_AVAILABLE: PropertyDefinition(
+        WILDCARD_SUBSCRIPTION_AVAILABLE,
+        "Wildcard Subscription Available",
+        PropertyWireType.BYTE,
+        frozenset({PACKET_CONNACK}),
+    ),
+    SUBSCRIPTION_IDENTIFIER_AVAILABLE: PropertyDefinition(
+        SUBSCRIPTION_IDENTIFIER_AVAILABLE,
+        "Subscription Identifier Available",
+        PropertyWireType.BYTE,
+        frozenset({PACKET_CONNACK}),
+    ),
+    SHARED_SUBSCRIPTION_AVAILABLE: PropertyDefinition(
+        SHARED_SUBSCRIPTION_AVAILABLE,
+        "Shared Subscription Available",
+        PropertyWireType.BYTE,
+        frozenset({PACKET_CONNACK}),
+    ),
+}
+
+
+def definition_for(identifier: int) -> PropertyDefinition:
+    """Return metadata for an MQTT 5.0 property identifier."""
+    return PROPERTY_DEFINITIONS[identifier]

--- a/tests/mqtt5/test_properties.py
+++ b/tests/mqtt5/test_properties.py
@@ -1,0 +1,166 @@
+import asyncio
+
+import pytest
+from hypothesis import given, strategies as st
+
+from amqtt.adapters import BufferReader
+from amqtt.errors import MQTTError
+from amqtt.mqtt3.packet import CONNECT, MQTTFixedHeader
+from amqtt.mqtt5.properties import Properties
+from amqtt.mqtt5.property_ids import (
+    ASSIGNED_CLIENT_IDENTIFIER,
+    AUTHENTICATION_DATA,
+    AUTHENTICATION_METHOD,
+    CONTENT_TYPE,
+    CORRELATION_DATA,
+    MAXIMUM_PACKET_SIZE,
+    MAXIMUM_QOS,
+    MESSAGE_EXPIRY_INTERVAL,
+    PAYLOAD_FORMAT_INDICATOR,
+    PROPERTY_DEFINITIONS,
+    PropertyWireType,
+    REASON_STRING,
+    RECEIVE_MAXIMUM,
+    REQUEST_PROBLEM_INFORMATION,
+    REQUEST_RESPONSE_INFORMATION,
+    RESPONSE_INFORMATION,
+    RESPONSE_TOPIC,
+    RETAIN_AVAILABLE,
+    SERVER_KEEP_ALIVE,
+    SERVER_REFERENCE,
+    SESSION_EXPIRY_INTERVAL,
+    SHARED_SUBSCRIPTION_AVAILABLE,
+    SUBSCRIPTION_IDENTIFIER,
+    SUBSCRIPTION_IDENTIFIER_AVAILABLE,
+    TOPIC_ALIAS,
+    TOPIC_ALIAS_MAXIMUM,
+    USER_PROPERTY,
+    WILDCARD_SUBSCRIPTION_AVAILABLE,
+    WILL_DELAY_INTERVAL,
+)
+
+
+def sample_value(wire_type: PropertyWireType):
+    if wire_type is PropertyWireType.BYTE:
+        return 1
+    if wire_type is PropertyWireType.TWO_BYTE_INTEGER:
+        return 42
+    if wire_type is PropertyWireType.FOUR_BYTE_INTEGER:
+        return 300
+    if wire_type is PropertyWireType.VARIABLE_BYTE_INTEGER:
+        return 321
+    if wire_type is PropertyWireType.UTF8_STRING:
+        return "value"
+    if wire_type is PropertyWireType.UTF8_STRING_PAIR:
+        return ("key", "value")
+    if wire_type is PropertyWireType.BINARY_DATA:
+        return b"value"
+    raise AssertionError(wire_type)
+
+
+@pytest.mark.parametrize("identifier", sorted(PROPERTY_DEFINITIONS))
+def test_property_round_trip_for_every_identifier(identifier: int):
+    properties = Properties()
+    properties.set(identifier, sample_value(PROPERTY_DEFINITIONS[identifier].wire_type))
+
+    decoded = Properties.decode(properties.encode())
+
+    assert decoded == properties
+
+
+@pytest.mark.parametrize(
+    ("identifier", "value", "expected_wire"),
+    [
+        (PAYLOAD_FORMAT_INDICATOR, 1, b"\x01\x01"),
+        (MESSAGE_EXPIRY_INTERVAL, 60, b"\x02\x00\x00\x00\x3c"),
+        (CONTENT_TYPE, "text/plain", b"\x03\x00\x0atext/plain"),
+        (RESPONSE_TOPIC, "reply/to", b"\x08\x00\x08reply/to"),
+        (CORRELATION_DATA, b"abc", b"\x09\x00\x03abc"),
+        (SUBSCRIPTION_IDENTIFIER, 42, b"\x0b\x2a"),
+        (SESSION_EXPIRY_INTERVAL, 300, b"\x11\x00\x00\x01\x2c"),
+        (ASSIGNED_CLIENT_IDENTIFIER, "client-1", b"\x12\x00\x08client-1"),
+        (SERVER_KEEP_ALIVE, 30, b"\x13\x00\x1e"),
+        (AUTHENTICATION_METHOD, "token", b"\x15\x00\x05token"),
+        (AUTHENTICATION_DATA, b"secret", b"\x16\x00\x06secret"),
+        (REQUEST_PROBLEM_INFORMATION, 1, b"\x17\x01"),
+        (WILL_DELAY_INTERVAL, 5, b"\x18\x00\x00\x00\x05"),
+        (REQUEST_RESPONSE_INFORMATION, 1, b"\x19\x01"),
+        (RESPONSE_INFORMATION, "info", b"\x1a\x00\x04info"),
+        (SERVER_REFERENCE, "mqtt://other", b"\x1c\x00\x0cmqtt://other"),
+        (REASON_STRING, "ok", b"\x1f\x00\x02ok"),
+        (RECEIVE_MAXIMUM, 10, b"\x21\x00\x0a"),
+        (TOPIC_ALIAS_MAXIMUM, 4, b"\x22\x00\x04"),
+        (TOPIC_ALIAS, 2, b"\x23\x00\x02"),
+        (MAXIMUM_QOS, 1, b"\x24\x01"),
+        (RETAIN_AVAILABLE, 1, b"\x25\x01"),
+        (USER_PROPERTY, ("k", "v"), b"\x26\x00\x01k\x00\x01v"),
+        (MAXIMUM_PACKET_SIZE, 1024, b"\x27\x00\x00\x04\x00"),
+        (WILDCARD_SUBSCRIPTION_AVAILABLE, 1, b"\x28\x01"),
+        (SUBSCRIPTION_IDENTIFIER_AVAILABLE, 1, b"\x29\x01"),
+        (SHARED_SUBSCRIPTION_AVAILABLE, 1, b"\x2a\x01"),
+    ],
+)
+def test_property_wire_bytes(identifier: int, value, expected_wire: bytes):
+    properties = Properties()
+    properties.set(identifier, value)
+
+    encoded = properties.encode()
+
+    assert encoded == bytes([len(expected_wire)]) + expected_wire
+    assert Properties.decode(encoded) == properties
+
+
+def test_decode_spec_example_empty_properties():
+    assert Properties().encode() == b"\x00"
+    assert Properties.decode(b"\x00") == Properties()
+
+
+def test_duplicate_non_repeatable_property_raises():
+    properties = Properties()
+    properties.set(CONTENT_TYPE, "text/plain")
+
+    with pytest.raises(MQTTError):
+        properties.set(CONTENT_TYPE, "application/json")
+
+
+def test_duplicate_user_properties_are_preserved_in_order():
+    properties = Properties()
+    properties.set(USER_PROPERTY, ("key", "one"))
+    properties.set(USER_PROPERTY, ("key", "two"))
+
+    decoded = Properties.decode(properties.encode())
+
+    assert decoded.get(USER_PROPERTY) == [("key", "one"), ("key", "two")]
+
+
+def test_decode_duplicate_non_repeatable_property_raises():
+    duplicate_content_type = b"\x16\x03\x00\x04text\x03\x00\x04json"
+
+    with pytest.raises(MQTTError):
+        Properties.decode(duplicate_content_type)
+
+
+@pytest.mark.parametrize("data", [b"", b"\x02\x03", b"\x01\xff", b"\x05\x03\x00\xffbad", b"\x00\x01"])
+def test_malformed_properties_raise_mqtt_error(data: bytes):
+    with pytest.raises(MQTTError):
+        Properties.decode(data)
+
+
+@given(st.binary())
+def test_properties_decode_never_crashes(data: bytes):
+    try:
+        Properties.decode(data)
+    except MQTTError:
+        pass
+
+
+def test_mqtt3_fixed_header_uses_shared_variable_byte_integer_helpers():
+    header = MQTTFixedHeader(CONNECT, 0x00, 16_384)
+    data = header.to_bytes()
+    stream = BufferReader(data)
+
+    decoded = asyncio.run(MQTTFixedHeader.from_stream(stream))
+
+    assert data == b"\x10\x80\x80\x01"
+    assert decoded is not None
+    assert decoded.remaining_length == 16_384

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -5,8 +5,11 @@ from amqtt.adapters import StreamReaderAdapter
 from amqtt.codecs_amqtt import (
     bytes_to_hex_str,
     bytes_to_int,
+    decode_variable_byte_int,
     decode_string,
+    encode_variable_byte_int,
     encode_string,
+    int_to_bytes,
 )
 
 
@@ -23,6 +26,21 @@ class TestCodecs(unittest.TestCase):
         assert ret == 127
         ret = bytes_to_int(b"\xff\xff")
         assert ret == 65535
+
+    def test_int_to_bytes_supports_four_byte_values(self):
+        assert int_to_bytes(0xFFFF_FFFF, 4) == b"\xff\xff\xff\xff"
+
+    def test_variable_byte_integer_round_trip(self):
+        for value, encoded in [
+            (0, b"\x00"),
+            (127, b"\x7f"),
+            (128, b"\x80\x01"),
+            (16_383, b"\xff\x7f"),
+            (16_384, b"\x80\x80\x01"),
+            (268_435_455, b"\xff\xff\xff\x7f"),
+        ]:
+            assert encode_variable_byte_int(value) == encoded
+            assert decode_variable_byte_int(encoded) == (value, len(encoded))
 
     def test_decode_string(self):
         stream = asyncio.StreamReader(loop=self.loop)


### PR DESCRIPTION
## Summary
- add MQTT 5 property identifiers and metadata
- implement MQTT 5 Properties encode and decode support
- centralize Variable Byte Integer helpers and reuse them in MQTT 3 fixed-header parsing
- add properties and codecs regression tests

## Base
This PR is stacked on upstream/mqtt3-namespace-and-mqtt5-scaffold so the diff contains only Issue 001 properties work.

## Tests
uv run pytest tests/mqtt5/test_properties.py tests/test_codecs.py tests/mqtt/test_packet.py -v